### PR TITLE
fix: use specific exceptions and idiomatic None checks

### DIFF
--- a/funasr_detach/auto/auto_model.py
+++ b/funasr_detach/auto/auto_model.py
@@ -22,7 +22,7 @@ from funasr_detach.models.campplus.utils import sv_chunk, postprocess, distribut
 
 try:
     from funasr_detach.models.campplus.cluster_backend import ClusterBackend
-except:
+except ImportError:
     print("If you want to use the speaker diarization, please `pip install hdbscan`")
 
 

--- a/funasr_detach/datasets/audio_datasets/index_ds.py
+++ b/funasr_detach/datasets/audio_datasets/index_ds.py
@@ -43,7 +43,7 @@ class IndexDSJsonlRankSplit(torch.utils.data.Dataset):
         try:
             rank = dist.get_rank()
             world_size = dist.get_world_size()
-        except:
+        except RuntimeError:
             rank = 0
             world_size = 1
             logging.warning("distributed is not initialized, only single shard")
@@ -65,7 +65,7 @@ class IndexDSJsonlRankSplit(torch.utils.data.Dataset):
     def __getitem__(self, index):
         try:
             data = self.contents[index]
-        except:
+        except (IndexError, KeyError):
             print(index)
         return data
 

--- a/funasr_detach/models/bicif_paraformer/model.py
+++ b/funasr_detach/models/bicif_paraformer/model.py
@@ -247,7 +247,7 @@ class BiCifParaformer(Paraformer):
 
         # init beamsearch
         is_use_ctc = (
-            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc != None
+            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc is not None
         )
         is_use_lm = (
             kwargs.get("lm_weight", 0.0) > 0.00001

--- a/funasr_detach/models/contextual_paraformer/model.py
+++ b/funasr_detach/models/contextual_paraformer/model.py
@@ -386,7 +386,7 @@ class ContextualParaformer(Paraformer):
     ):
         # init beamsearch
         is_use_ctc = (
-            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc != None
+            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc is not None
         )
         is_use_lm = (
             kwargs.get("lm_weight", 0.0) > 0.00001

--- a/funasr_detach/models/paraformer/model.py
+++ b/funasr_detach/models/paraformer/model.py
@@ -419,7 +419,7 @@ class Paraformer(torch.nn.Module):
         # 1. Build ASR model
         scorers = {}
 
-        if self.ctc != None:
+        if self.ctc is not None:
             ctc = CTCPrefixScorer(ctc=self.ctc, eos=self.eos)
             scorers.update(ctc=ctc)
         token_list = kwargs.get("token_list")
@@ -466,7 +466,7 @@ class Paraformer(torch.nn.Module):
     ):
         # init beamsearch
         is_use_ctc = (
-            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc != None
+            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc is not None
         )
         is_use_lm = (
             kwargs.get("lm_weight", 0.0) > 0.00001

--- a/funasr_detach/models/paraformer_streaming/model.py
+++ b/funasr_detach/models/paraformer_streaming/model.py
@@ -635,7 +635,7 @@ class ParaformerStreaming(Paraformer):
 
         # init beamsearch
         is_use_ctc = (
-            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc != None
+            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc is not None
         )
         is_use_lm = (
             kwargs.get("lm_weight", 0.0) > 0.00001

--- a/funasr_detach/models/scama/model.py
+++ b/funasr_detach/models/scama/model.py
@@ -491,7 +491,7 @@ class SCAMA(nn.Module):
         # 1. Build ASR model
         scorers = {}
 
-        if self.ctc != None:
+        if self.ctc is not None:
             ctc = CTCPrefixScorer(ctc=self.ctc, eos=self.eos)
             scorers.update(ctc=ctc)
         token_list = kwargs.get("token_list")
@@ -673,7 +673,7 @@ class SCAMA(nn.Module):
 
         # init beamsearch
         is_use_ctc = (
-            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc != None
+            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc is not None
         )
         is_use_lm = (
             kwargs.get("lm_weight", 0.0) > 0.00001

--- a/funasr_detach/models/seaco_paraformer/model.py
+++ b/funasr_detach/models/seaco_paraformer/model.py
@@ -384,7 +384,7 @@ class SeacoParaformer(BiCifParaformer, Paraformer):
 
         # init beamsearch
         is_use_ctc = (
-            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc != None
+            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc is not None
         )
         is_use_lm = (
             kwargs.get("lm_weight", 0.0) > 0.00001

--- a/funasr_detach/models/transducer/model.py
+++ b/funasr_detach/models/transducer/model.py
@@ -426,7 +426,7 @@ class Transducer(torch.nn.Module):
         # 1. Build ASR model
         scorers = {}
 
-        if self.ctc != None:
+        if self.ctc is not None:
             ctc = CTCPrefixScorer(ctc=self.ctc, eos=self.eos)
             scorers.update(ctc=ctc)
         token_list = kwargs.get("token_list")
@@ -465,7 +465,7 @@ class Transducer(torch.nn.Module):
 
         # init beamsearch
         is_use_ctc = (
-            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc != None
+            kwargs.get("decoding_ctc_weight", 0.0) > 0.00001 and self.ctc is not None
         )
         is_use_lm = (
             kwargs.get("lm_weight", 0.0) > 0.00001

--- a/funasr_detach/models/transformer/model.py
+++ b/funasr_detach/models/transformer/model.py
@@ -330,7 +330,7 @@ class Transformer(nn.Module):
         # 1. Build ASR model
         scorers = {}
 
-        if self.ctc != None:
+        if self.ctc is not None:
             ctc = CTCPrefixScorer(ctc=self.ctc, eos=self.eos)
             scorers.update(ctc=ctc)
         token_list = kwargs.get("token_list")

--- a/funasr_detach/models/uniasr/model.py
+++ b/funasr_detach/models/uniasr/model.py
@@ -930,7 +930,7 @@ class UniASR(torch.nn.Module):
         # 1. Build ASR model
         scorers = {}
 
-        if self.ctc != None:
+        if self.ctc is not None:
             ctc = CTCPrefixScorer(ctc=self.ctc, eos=self.eos)
             scorers.update(ctc=ctc)
         token_list = kwargs.get("token_list")


### PR DESCRIPTION
## Changes

### Bare except → specific exceptions
- `auto_model.py`: `except ImportError` for optional hdbscan
- `index_ds.py`: `except RuntimeError` for distributed init, `except (IndexError, KeyError)` for data access

### `!= None` → `is not None` (PEP 8 E711)
Fixed across 10 model files for `self.ctc` singleton checks.