### PR TITLE
Add token-level GRPO training template

### DIFF
--- a/scripts/ReadMe.md
+++ b/scripts/ReadMe.md
@@ -195,16 +195,53 @@ Set the `REWARD_FUNCS` parameter to "gemini":
 REWARD_FUNCS="gemini"
 ```
 
+#### 5.3.3 Token-level Local Consistency GRPO
+For token-level local consistency training, the GRPO dataset should also provide `target_vq02vq06` so the reward can compare the generated sequence against the target codec units.
+
+Example JSONL sample:
+```json
+{
+    "source_text": "Original transcript with filler words",
+    "source_vq02vq06": "Source audio tokens",
+    "target_text": "Edited transcript after removing filler words",
+    "target_vq02vq06": "Target audio tokens",
+    "task_type": "edit",
+    "edit_type": "mask",
+    "edit_info": "empty"
+}
+```
+
+The project provides four token-level rewards:
+
+- `token_level_edit`
+- `token_level_consistency`
+- `token_level_follow`
+- `token_level_length`
+
+Legacy aliases `mask_edit`, `mask_consistency`, `mask_follow`, and `mask_length` are also supported. Use `--mask_reward_weights` if you want to scale those rewards individually. The template scripts keep all weights at `1.0`:
+
+```bash
+--mask_reward_weights "token_level_edit:1.0,token_level_consistency:1.0,token_level_follow:1.0,token_level_length:1.0"
+```
+
+If you only enable these token-level rewards, the Flow-matching reward server is not required.
+
 
 ### 5.4 Launching Training
 
 Once the Flow-matching service is running (port listening without errors) and reward functions are defined, you can start training.
 
-The project provides two scripts:
+The project provides four scripts:
 
 - `run_edit_grpo.sh`: Uses standard Hugging Face inference mode.
 
 - `run_edit_grpo_vllm.sh`: Uses vLLM for inference sampling, providing faster speeds and better VRAM efficiency.
+
+- `run_edit_grpo_token_level.sh`: Uses token-level local consistency rewards in standard Hugging Face inference mode.
+
+- `run_edit_grpo_token_level_vllm.sh`: Uses token-level local consistency rewards together with vLLM sampling.
+
+Both scripts are intentionally conservative templates. Parameters such as `num_generations` are set to `1` by default and can be adjusted by users in their own environments.
 
 Update the parameters in the `./scripts/` directory before execution:
 ```bash
@@ -243,6 +280,3 @@ SERVER_IP="127.0.0.1"                     # IP of the Flow-matching service
 | `--use_vllm` | `false` | Enable vLLM acceleration for faster inference sampling. |
 | `--vllm_mode` | `"colocate"` | Deployment mode for vLLM. |
 | `--vllm_gpu_memory_utilization` | `0.3` | Percentage of VRAM (0.0-1.0) allocated for vLLM. |
-
-
-

--- a/scripts/ReadMe_zh.md
+++ b/scripts/ReadMe_zh.md
@@ -200,12 +200,45 @@ export API_KEY="您的_GEMINI_API_KEY"
 REWARD_FUNCS="gemini"
 ```
 
+#### 5.3.3 Token-level 局部一致性 GRPO
+如果希望使用 token-level 的局部一致性奖励，GRPO 数据集中还需要提供 `target_vq02vq06`，用于将生成结果和目标 codec 单元做对齐比较。
+
+示例 JSONL 如下：
+```json
+{
+    "source_text": "包含口水词或语气词的原始文本",
+    "source_vq02vq06": "source_audio 音频 token 序列",
+    "target_text": "删除口水词后的目标文本",
+    "target_vq02vq06": "目标音频 token 序列",
+    "task_type": "edit",
+    "edit_type": "mask",
+    "edit_info": "empty"
+}
+```
+
+项目内置了 4 个 token-level reward：
+
+- `token_level_edit`
+- `token_level_consistency`
+- `token_level_follow`
+- `token_level_length`
+
+同时兼容历史别名 `mask_edit`、`mask_consistency`、`mask_follow`、`mask_length`。如果需要单独调节各 reward 权重，可在启动脚本中加入；模板脚本默认都设为 `1.0`：
+
+```bash
+--mask_reward_weights "token_level_edit:1.0,token_level_consistency:1.0,token_level_follow:1.0,token_level_length:1.0"
+```
+
+如果你只启用这些 token-level reward，则不需要额外部署 Flow-matching reward server。
+
 
 ### 5.4 训练脚本启动
 
 在确认 Flow-matching 服务已成功启动（端口正常监听且无报错）并完成奖励函数定义后，即可开始训练。
 
-项目提供了两个训练脚本，`run_edit_grpo.sh`使用标准的Huggingface 推理模式，`run_edit_grpo_vllm.sh`则使用 vLLM 进行推理采样，速度更快，显存利用率更高，请根据显存资源和速度需求进行选择。
+项目提供了四个训练脚本。`run_edit_grpo.sh` 使用标准 Hugging Face 推理模式，`run_edit_grpo_vllm.sh` 使用 vLLM 进行推理采样；另外还新增了 `run_edit_grpo_token_level.sh` 和 `run_edit_grpo_token_level_vllm.sh`，用于 token-level 局部一致性 GRPO 训练。
+
+这两个 token-level 脚本刻意保持为保守模板，像 `num_generations` 这类参数默认设为 `1`，需要时由使用者自行调整。
 
 在执行脚本前，请根据实际环境修改 `./scripts/` 目录下的脚本参数：
 ```bash
@@ -245,6 +278,3 @@ SERVER_IP="127.0.0.1"                     # Flow-matching 推理服务的 IP 地
 | `--use_vllm` | `false` | **启用 vLLM 加速**。开启后将使用 vLLM 引擎进行推理采样，能大幅提升采样速度并优化显存分配。 |
 | `--vllm_mode` | `"colocate"` | **部署模式**。通常设为 `colocate`。 |
 | `--vllm_gpu_memory_utilization` | `0.3` | **推理显存占用比**。指定 vLLM 占用的显存百分比（0.0-1.0）。 |
-
-
-

--- a/scripts/run_edit_grpo_token_level.sh
+++ b/scripts/run_edit_grpo_token_level.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# --- Path Configuration ---
+MODEL_PATH="{EDITX_PATH}"
+# --- [Supports multiple data files; please use array format] ---
+DATA_FILES=(
+    "{TRAINING_INDEX_FILE}"
+    # "xxxxx"
+    # Additional files can be added here...
+)
+OUTPUT_DIR="{YOUR_PATH_TO_SAVE_CHECKPOINT}"
+LOG_ROOT="{YOUR_PATH_TO_LOG_TRAINING_PROCESS}"
+CONFIG_PATH="./config/train_config/accelerate_configs/deepspeed_zero2.yaml"
+
+# --- Auto-generate Timestamp Suffix ---
+TIMESTAMP=$(date "+%Y%m%d_%H%M%S")
+LOG_FILE="${LOG_ROOT}/training_log_${TIMESTAMP}.txt"
+
+# --- Directory Creation ---
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$LOG_ROOT"
+
+# --- Hardware & Distributed Parameters ---
+GPU_NUM=8
+MASTER_PORT=$(shuf -n 1 -i 10000-65535)
+
+# --- Log Basic Information (Using tee -a to output to both screen and log file) ---
+{
+    echo "------------------------------------------------"
+    echo "Starting training at: $(date)"
+    echo "Log file: $LOG_FILE"
+    echo "Output Dir: $OUTPUT_DIR"
+    echo "------------------------------------------------"
+} | tee -a "$LOG_FILE"
+
+REWARD_FUNCS=(
+    "token_level_edit"
+    "token_level_consistency"
+    "token_level_follow"
+    "token_level_length"
+)
+TOKEN_LEVEL_REWARD_WEIGHTS="token_level_edit:1.0,token_level_consistency:1.0,token_level_follow:1.0,token_level_length:1.0"
+# Kept for CLI compatibility. Token-level rewards do not call the flow server.
+SERVER_IP="127.0.0.1"
+
+# --- Construct Command Array ---
+# Using an array keeps parameters organized and makes printing easier
+CMD_ARGS=(
+    accelerate launch
+    --config_file "${CONFIG_PATH}"
+    --num_processes ${GPU_NUM}
+    --main_process_port ${MASTER_PORT}
+    src/train_edit.py
+    --model_name_or_path "$MODEL_PATH"
+    --data_files "${DATA_FILES[@]}"
+    --output_dir "$OUTPUT_DIR"
+    --reward_server_ip "$SERVER_IP"
+    --reward_server_num 1
+    --reward_funcs "${REWARD_FUNCS[@]}"
+    --mask_reward_weights "$TOKEN_LEVEL_REWARD_WEIGHTS"
+    --max_text_length 512
+    --max_audio_tokens 1024
+    --run_name "Edit-GRPO-Token-Level"
+    --num_train_epochs 1
+    --per_device_train_batch_size 1
+    --gradient_accumulation_steps 1
+    --learning_rate 1e-6
+    --lr_scheduler_type "cosine"
+    --warmup_ratio 0.03
+    --logging_steps 1
+    --save_steps 50
+    --save_total_limit 2
+    --bf16 true
+    --gradient_checkpointing true
+    --num_generations 1
+    --temperature 1.0
+    --beta 0.1
+    --resume_from_checkpoint True
+    --report_to "wandb"
+    --ddp_timeout 5400
+)
+
+# --- Write full execution parameters to log ---
+echo -e "\n[Executing Command]:" >> "$LOG_FILE"
+echo "${CMD_ARGS[*]}" >> "$LOG_FILE"
+echo -e "------------------------------------------------\n" >> "$LOG_FILE"
+
+# --- Execute Training ---
+"${CMD_ARGS[@]}" >> "$LOG_FILE" 2>&1
+
+# Check Exit Status
+EXIT_STATUS=$?
+if [ $EXIT_STATUS -eq 0 ]; then
+    echo "Training completed successfully. Log: $LOG_FILE" | tee -a "$LOG_FILE"
+else
+    echo "Training failed with status $EXIT_STATUS. Please check log: $LOG_FILE" | tee -a "$LOG_FILE"
+fi

--- a/scripts/run_edit_grpo_token_level_vllm.sh
+++ b/scripts/run_edit_grpo_token_level_vllm.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# --- Path Configuration ---
+MODEL_PATH="{EDITX_PATH}"
+# --- [Supports multiple data files; please use array format] ---
+DATA_FILES=(
+    "{TRAINING_INDEX_FILE}"
+    # "xxxxx"
+    # Additional files can be added here...
+)
+OUTPUT_DIR="{YOUR_PATH_TO_SAVE_CHECKPOINT}"
+LOG_ROOT="{YOUR_PATH_TO_LOG_TRAINING_PROCESS}"
+CONFIG_PATH="./config/train_config/accelerate_configs/deepspeed_zero2.yaml"
+
+# --- Auto-generate Timestamp Suffix ---
+TIMESTAMP=$(date "+%Y%m%d_%H%M%S")
+LOG_FILE="${LOG_ROOT}/training_log_${TIMESTAMP}.txt"
+
+# --- Directory Creation ---
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$LOG_ROOT"
+
+# --- Hardware & Distributed Parameters ---
+GPU_NUM=8
+MASTER_PORT=$(shuf -n 1 -i 10000-65535)
+
+# --- Log Basic Information (Using tee -a to output to both screen and log file) ---
+{
+    echo "------------------------------------------------"
+    echo "Starting training at: $(date)"
+    echo "Log file: $LOG_FILE"
+    echo "Output Dir: $OUTPUT_DIR"
+    echo "------------------------------------------------"
+} | tee -a "$LOG_FILE"
+
+REWARD_FUNCS=(
+    "token_level_edit"
+    "token_level_consistency"
+    "token_level_follow"
+    "token_level_length"
+)
+TOKEN_LEVEL_REWARD_WEIGHTS="token_level_edit:1.0,token_level_consistency:1.0,token_level_follow:1.0,token_level_length:1.0"
+# Kept for CLI compatibility. Token-level rewards do not call the flow server.
+SERVER_IP="127.0.0.1"
+
+# --- Construct Command Array ---
+# Using an array keeps parameters organized and makes printing easier
+CMD_ARGS=(
+    accelerate launch
+    --config_file "${CONFIG_PATH}"
+    --num_processes ${GPU_NUM}
+    --main_process_port ${MASTER_PORT}
+    src/train_edit.py
+    --model_name_or_path "$MODEL_PATH"
+    --data_files "${DATA_FILES[@]}"
+    --output_dir "$OUTPUT_DIR"
+    --use_vllm
+    --vllm_mode "colocate"
+    --vllm_gpu_memory_utilization 0.3
+    --vllm_max_model_length 1536
+    --reward_server_ip "$SERVER_IP"
+    --reward_server_num 1
+    --reward_funcs "${REWARD_FUNCS[@]}"
+    --mask_reward_weights "$TOKEN_LEVEL_REWARD_WEIGHTS"
+    --max_text_length 512
+    --max_audio_tokens 1024
+    --run_name "Edit-GRPO-Token-Level-vLLM"
+    --num_train_epochs 1
+    --per_device_train_batch_size 1
+    --gradient_accumulation_steps 1
+    --learning_rate 1e-6
+    --lr_scheduler_type "cosine"
+    --warmup_ratio 0.03
+    --logging_steps 1
+    --save_steps 25
+    --save_total_limit 2
+    --bf16 true
+    --gradient_checkpointing true
+    --num_generations 1
+    --temperature 1.0
+    --beta 0.1
+    --resume_from_checkpoint True
+    --report_to "wandb"
+    --ddp_timeout 5400
+)
+
+# --- Write full execution parameters to log ---
+echo -e "\n[Executing Command]:" >> "$LOG_FILE"
+echo "${CMD_ARGS[*]}" >> "$LOG_FILE"
+echo -e "------------------------------------------------\n" >> "$LOG_FILE"
+
+# --- Execute Training ---
+"${CMD_ARGS[@]}" >> "$LOG_FILE" 2>&1
+
+# Check Exit Status
+EXIT_STATUS=$?
+if [ $EXIT_STATUS -eq 0 ]; then
+    echo "Training completed successfully. Log: $LOG_FILE" | tee -a "$LOG_FILE"
+else
+    echo "Training failed with status $EXIT_STATUS. Please check log: $LOG_FILE" | tee -a "$LOG_FILE"
+fi

--- a/src/dataset/edit_dataset.py
+++ b/src/dataset/edit_dataset.py
@@ -90,8 +90,20 @@ class EditDataset(Dataset):
                     try:
                         item = json.loads(line.strip())
                         
-                        # required_keys = ['source_audio', 'source_text', 'source_vq02vq06', 'target_audio', 'target_text', 'target_vq02vq06', 'edit_type', 'edit_info']
-                        required_keys = ['source_audio', 'source_text', 'source_vq02vq06', 'target_text']
+                        is_token_level_mask = (
+                            item.get("task_type", "edit") == "edit"
+                            and str(item.get("edit_type", "")).lower() == "mask"
+                        )
+                        if is_token_level_mask:
+                            required_keys = [
+                                'source_text',
+                                'source_vq02vq06',
+                                'target_text',
+                                'edit_type',
+                                'edit_info',
+                            ]
+                        else:
+                            required_keys = ['source_audio', 'source_text', 'source_vq02vq06', 'target_text']
                         if not all(key in item for key in required_keys):
                             # logging.debug(f"Missing required fields in line {line_idx} of {file_path}")
                             continue
@@ -101,9 +113,10 @@ class EditDataset(Dataset):
                         if item['task_type'] == "edit":
                             processed_item = {
                                 'source_text': item['source_text'],
-                                'source_audio': item['source_audio'],
+                                'source_audio': item.get('source_audio', ''),
                                 'source_vq02vq06': item['source_vq02vq06'],
                                 'target_text': item['target_text'],
+                                'target_vq02vq06': item.get('target_vq02vq06'),
                                 'task_type': item['task_type'],
                                 'edit_type': item['edit_type'],
                                 'edit_info': item['edit_info'],
@@ -166,6 +179,19 @@ class EditDataset(Dataset):
             instruct_prefix = f"Remove any silent portions from the given audio while preserving the voice content clearly. Ensure that the speech quality remains intact with minimal distortion, and eliminate all silence from the audio.\n"
         elif edit_type == "paralinguistic":
             instruct_prefix = f"Add some non-verbal sounds to make the audio more natural, the new text is : {text}\n  The text corresponding to the audio is: {audio_text}\n"
+        elif edit_type == "mask":
+            if safe_edit_info.lower() == "empty":
+                instruct_prefix = (
+                    f"Remove filler words and hesitation sounds, the new text is : {text}\n"
+                    f" The text corresponding to the audio is: {audio_text}\n"
+                )
+            elif safe_edit_info.lower() == "tone":
+                instruct_prefix = (
+                    f"Remove all interjections and emotional particles, the new text is : {text}\n"
+                    f" The text corresponding to the audio is: {audio_text}\n"
+                )
+            else:
+                instruct_prefix = f"Edit the audio based on text: {audio_text}\n"
         else:
             # 默认为空或抛出异常，视需求而定
             instruct_prefix = f"Edit the audio based on text: {audio_text}\n" 
@@ -188,7 +214,8 @@ class EditDataset(Dataset):
         item = self.data[idx]
         
         if item['task_type'] == "edit":
-            instruct_prefix = self._build_audio_edit_instruction(item['source_text'], item['edit_type'], item['edit_info'], item['source_text'])
+            target_instruction_text = item['target_text'] if str(item['edit_type']).lower() == "mask" else item['source_text']
+            instruct_prefix = self._build_audio_edit_instruction(item['source_text'], item['edit_type'], item['edit_info'], target_instruction_text)
             audio_str = self.processing_class.decode(item['source_vq02vq06'])
             messages = [
                 {"role": "system", "content": EDIT_SYS_PROMPT},
@@ -210,10 +237,10 @@ class EditDataset(Dataset):
             ]
             pass
 
-        return {
+        output = {
             'prompt': messages, 
             'source_text': item['source_text'], 
-            'source_audio': item['source_audio'],
+            'source_audio': item.get('source_audio', ''),
             'source_vq02vq06': item['source_vq02vq06'],
             'target_text': item['target_text'],
             'task_type': item['task_type'],
@@ -221,6 +248,9 @@ class EditDataset(Dataset):
             'edit_type': item['edit_type'],
             'edit_info': item['edit_info'],
         }
+        if item.get('target_vq02vq06') is not None:
+            output['target_vq02vq06'] = item['target_vq02vq06']
+        return output
  
     def collate_fn(self, batch: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         return batch

--- a/src/train_edit.py
+++ b/src/train_edit.py
@@ -33,6 +33,12 @@ from utils.reward_func import cer_reward_func, sim_reward_func, emo_reward_func,
 from utils.reward_func_gemini import gemini_reward_func
 from utils.reward_func_r1 import step_audio_r1_reward_func
 from utils.reward_func_genrm import genrm_reward_func
+from utils.reward_func_token import (
+    token_level_consistency_reward_func,
+    token_level_edit_reward_func,
+    token_level_follow_reward_func,
+    token_level_length_reward_func,
+)
 from dataset.edit_dataset import create_edit_dataset
 from transformers.trainer_utils import get_last_checkpoint
 import torch
@@ -134,7 +140,26 @@ class DataArguments:
     )
     reward_funcs: List[str] = field(
         default_factory=lambda: ["cer", "sim", "emo", "r1", "gemini", "mos"],
-        metadata={"help": "List of reward functions to use. Choices: cer, sim, emo, r1, gemini"}
+        metadata={
+            "help": (
+                "List of reward functions to use. "
+                "Choices include cer, sim, emo, r1, gemini, mos, my_genrm, "
+                "token_level_edit, token_level_consistency, token_level_follow, "
+                "token_level_length. "
+                "Legacy aliases mask_edit, mask_consistency, mask_follow, "
+                "mask_length are also supported."
+            )
+        }
+    )
+    mask_reward_weights: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Optional per-reward scaling for token-level rewards, for example "
+                "'token_level_edit:1.0,token_level_length:1.0'. "
+                "Legacy mask_* reward names are also supported."
+            )
+        }
     )
 
 def main():
@@ -172,6 +197,51 @@ def main():
         update_wrapper(f, func)
         f.__name__ = name 
         return f
+
+    reward_aliases = {
+        "mask_edit": "token_level_edit",
+        "mask_consistency": "token_level_consistency",
+        "mask_follow": "token_level_follow",
+        "mask_length": "token_level_length",
+    }
+
+    def register_alias_weight(name, value, reward_weights):
+        reward_weights[name] = value
+        if name in reward_aliases:
+            reward_weights[reward_aliases[name]] = value
+            return
+        for legacy_name, canonical_name in reward_aliases.items():
+            if canonical_name == name:
+                reward_weights[legacy_name] = value
+                break
+
+    reward_weights = {}
+    if data_args.mask_reward_weights:
+        for raw_item in data_args.mask_reward_weights.split(","):
+            item = raw_item.strip()
+            if not item:
+                continue
+            if ":" not in item:
+                raise ValueError(
+                    "Invalid mask_reward_weights item "
+                    f"'{item}'. Expected the format reward_name:weight."
+                )
+            reward_name, reward_value = item.split(":", 1)
+            register_alias_weight(
+                reward_name.strip(),
+                float(reward_value.strip()),
+                reward_weights,
+            )
+        if reward_weights:
+            logger.info(f"Token-level reward weights: {reward_weights}")
+
+    def apply_reward_weight(func, weight):
+        def wrapped(*args, **kwargs):
+            return [weight * value for value in func(*args, **kwargs)]
+
+        update_wrapper(wrapped, func)
+        wrapped.__name__ = getattr(func, "__name__", "weighted_reward")
+        return wrapped
     
     reward_registry = {
         "cer": cer_reward_func,
@@ -181,6 +251,14 @@ def main():
         "r1": step_audio_r1_reward_func,
         "mos": mos_reward_func,
         "my_genrm": genrm_reward_func,
+        "token_level_edit": token_level_edit_reward_func,
+        "token_level_consistency": token_level_consistency_reward_func,
+        "token_level_follow": token_level_follow_reward_func,
+        "token_level_length": token_level_length_reward_func,
+        "mask_edit": token_level_edit_reward_func,
+        "mask_consistency": token_level_consistency_reward_func,
+        "mask_follow": token_level_follow_reward_func,
+        "mask_length": token_level_length_reward_func,
     }
     selected_reward_funcs = []
     logger.info(f"Selected reward functions: {data_args.reward_funcs}")
@@ -189,6 +267,8 @@ def main():
         if name in reward_registry:
             func_name = f"{name}_reward"
             wrapped_func = make_reward_func(reward_registry[name], func_name)
+            if name in reward_weights:
+                wrapped_func = apply_reward_weight(wrapped_func, reward_weights[name])
             selected_reward_funcs.append(wrapped_func)
         else:
             raise ValueError(f"Reward function '{name}' is not supported. Available: {list(reward_registry.keys())}")

--- a/src/utils/reward_func_token.py
+++ b/src/utils/reward_func_token.py
@@ -1,0 +1,233 @@
+"""
+Token-level GRPO rewards for local consistency.
+
+The reward functions in this module operate on 5-token units. They are designed
+for edit tasks where the target sequence is expected to preserve most source
+units while removing or rewriting only a small local region.
+"""
+
+import math
+from typing import Any, Dict, List, Sequence, Tuple
+
+UNIT_SIZE = 5
+MODEL_EOS_TOKEN_ID = 3
+SEGMENT_SEARCH_MARGIN = 30
+
+Unit = Tuple[int, ...]
+
+
+def _strip_terminal_eos(token_ids: Sequence[int]) -> List[int]:
+    if token_ids and token_ids[-1] == MODEL_EOS_TOKEN_ID:
+        return list(token_ids[:-1])
+    return list(token_ids)
+
+
+def _split_into_units(tokens: Sequence[int]) -> List[Unit]:
+    usable_length = (len(tokens) // UNIT_SIZE) * UNIT_SIZE
+    return [
+        tuple(tokens[index:index + UNIT_SIZE])
+        for index in range(0, usable_length, UNIT_SIZE)
+    ]
+
+
+def _get_preserved_segments(source_units: List[Unit], target_units: List[Unit]) -> List[List[Unit]]:
+    segments: List[List[Unit]] = []
+    current_segment: List[Unit] = []
+    source_index = 0
+    target_index = 0
+
+    while source_index < len(source_units) and target_index < len(target_units):
+        if source_units[source_index] == target_units[target_index]:
+            current_segment.append(target_units[target_index])
+            source_index += 1
+            target_index += 1
+            continue
+
+        if current_segment:
+            segments.append(current_segment)
+            current_segment = []
+        source_index += 1
+
+    if current_segment:
+        segments.append(current_segment)
+
+    return segments
+
+
+def _unit_edit_distance(lhs: List[Unit], rhs: List[Unit]) -> int:
+    lhs_length = len(lhs)
+    rhs_length = len(rhs)
+    if lhs_length == 0:
+        return rhs_length
+    if rhs_length == 0:
+        return lhs_length
+
+    previous_row = list(range(rhs_length + 1))
+    for lhs_index in range(1, lhs_length + 1):
+        current_row = [lhs_index] + [0] * rhs_length
+        for rhs_index in range(1, rhs_length + 1):
+            substitution_cost = 0 if lhs[lhs_index - 1] == rhs[rhs_index - 1] else 1
+            current_row[rhs_index] = min(
+                previous_row[rhs_index] + 1,
+                current_row[rhs_index - 1] + 1,
+                previous_row[rhs_index - 1] + substitution_cost,
+            )
+        previous_row = current_row
+    return previous_row[rhs_length]
+
+
+def _segment_edit_reward(
+    output_units: List[Unit],
+    target_units: List[Unit],
+    source_units: List[Unit],
+) -> float:
+    preserved_segments = _get_preserved_segments(source_units, target_units)
+    if not preserved_segments:
+        return 0.0
+
+    segment_score_total = 0.0
+    current_search_pointer = 0
+
+    for segment in preserved_segments:
+        segment_length = len(segment)
+        search_end = min(
+            current_search_pointer + segment_length + SEGMENT_SEARCH_MARGIN,
+            len(output_units),
+        )
+        output_slice = output_units[current_search_pointer:search_end]
+        if not output_slice:
+            continue
+
+        edit_distance = _unit_edit_distance(output_slice, segment)
+        normalizer = max(len(output_slice), segment_length, 1)
+        segment_score_total += max(0.0, 1.0 - (edit_distance / normalizer))
+        current_search_pointer += max(1, segment_length - UNIT_SIZE)
+
+    return segment_score_total / len(preserved_segments)
+
+
+def _consistency_reward(output_units: List[Unit], source_units: List[Unit]) -> float:
+    if not output_units:
+        return 0.0
+    source_unit_set = set(source_units)
+    preserved_unit_count = sum(1 for unit in output_units if unit in source_unit_set)
+    return preserved_unit_count / len(output_units)
+
+
+def _normalize_sources_and_targets(
+    reward_kwargs: Dict[str, Any],
+    batch_size: int,
+) -> Tuple[List[List[int]], List[List[int]]]:
+    sources = reward_kwargs.get(
+        "source_vq02vq06",
+        reward_kwargs.get("source_token", [[]] * batch_size),
+    )
+    targets = reward_kwargs.get(
+        "target_vq02vq06",
+        reward_kwargs.get("target_token", [[]] * batch_size),
+    )
+
+    if sources and not isinstance(sources[0], (list, tuple)):
+        sources = [sources] * batch_size
+    if targets and not isinstance(targets[0], (list, tuple)):
+        targets = [targets] * batch_size
+
+    while len(sources) < batch_size:
+        sources.append([])
+    while len(targets) < batch_size:
+        targets.append([])
+
+    return sources, targets
+
+
+def token_level_edit_reward_func(
+    prompts: List[Any],
+    completions: List[Any],
+    completion_ids: List[List[int]],
+    **reward_kwargs: Any,
+) -> List[float]:
+    batch_size = len(completion_ids)
+    sources, targets = _normalize_sources_and_targets(reward_kwargs, batch_size)
+
+    reward_values = []
+    for batch_index in range(batch_size):
+        output_units = _split_into_units(_strip_terminal_eos(completion_ids[batch_index]))
+        target_units = _split_into_units(targets[batch_index])
+        source_units = _split_into_units(sources[batch_index])
+        reward_values.append(
+            _segment_edit_reward(output_units, target_units, source_units)
+        )
+    return reward_values
+
+
+def token_level_consistency_reward_func(
+    prompts: List[Any],
+    completions: List[Any],
+    completion_ids: List[List[int]],
+    **reward_kwargs: Any,
+) -> List[float]:
+    batch_size = len(completion_ids)
+    sources, _ = _normalize_sources_and_targets(reward_kwargs, batch_size)
+
+    return [
+        _consistency_reward(
+            _split_into_units(_strip_terminal_eos(completion_ids[batch_index])),
+            _split_into_units(sources[batch_index]),
+        )
+        for batch_index in range(batch_size)
+    ]
+
+
+def token_level_follow_reward_func(
+    prompts: List[Any],
+    completions: List[Any],
+    completion_ids: List[List[int]],
+    **reward_kwargs: Any,
+) -> List[float]:
+    batch_size = len(completion_ids)
+    sources, targets = _normalize_sources_and_targets(reward_kwargs, batch_size)
+
+    reward_values = []
+    for batch_index in range(batch_size):
+        output_units = _split_into_units(_strip_terminal_eos(completion_ids[batch_index]))
+        source_units = _split_into_units(sources[batch_index])
+        target_units = _split_into_units(targets[batch_index])
+        preserved_segments = _get_preserved_segments(source_units, target_units)
+
+        hits = 0
+        current_index = 0
+        for segment in preserved_segments:
+            anchor_unit = segment[0]
+            for output_index in range(current_index, len(output_units)):
+                if output_units[output_index] == anchor_unit:
+                    hits += 1
+                    current_index = output_index + 1
+                    break
+
+        reward_values.append(hits / len(preserved_segments) if preserved_segments else 1.0)
+
+    return reward_values
+
+
+def token_level_length_reward_func(
+    prompts: List[Any],
+    completions: List[Any],
+    completion_ids: List[List[int]],
+    **reward_kwargs: Any,
+) -> List[float]:
+    batch_size = len(completion_ids)
+    _, targets = _normalize_sources_and_targets(reward_kwargs, batch_size)
+
+    reward_values = []
+    for batch_index in range(batch_size):
+        output_tokens = _strip_terminal_eos(completion_ids[batch_index])
+        target_tokens = targets[batch_index]
+        if not target_tokens:
+            reward_values.append(1.0 if not output_tokens else 0.0)
+            continue
+
+        token_length_difference = abs(len(output_tokens) - len(target_tokens))
+        denominator = max(len(target_tokens) / UNIT_SIZE, 1) * 0.1 + 1
+        reward_values.append(math.exp(-(token_length_difference / UNIT_SIZE) / denominator))
+
+    return reward_values


### PR DESCRIPTION
## Summary
- add a token-level GRPO reward module for local consistency training
- extend the edit dataset so token-level GRPO can consume `target_vq02vq06` and mask edit prompts
- add dedicated token-level GRPO launch templates for standard and vLLM-based training
- document the token-level workflow with conservative public defaults

## Validation
- `python3 -m py_compile src/train_edit.py src/utils/reward_func_token.py`
- `bash -n scripts/run_edit_grpo_token_level.sh scripts/run_edit_grpo_token_level_vllm.sh`
- 1-step local token-level GRPO smoke test
